### PR TITLE
create-postgres-stg-data-02-teste-sre-dois-kitchen-teste-sre

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,6 @@
 name: 'TESTE Review'
 on: [pull_request]
 
-permissions:
-  contents: read
-
 jobs:
   dependency-review:
     runs-on: ubuntu-latest

--- a/prod-eks-03/argocd/applications/stg-data-02/teste-sre-dois/postgres-kitchen-teste-sre.yaml
+++ b/prod-eks-03/argocd/applications/stg-data-02/teste-sre-dois/postgres-kitchen-teste-sre.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stg-data-02-postgres-kitchen-teste-sre
+  namespace: argocd
+spec:
+  project: stg-data-02-teste-sre-dois
+  ignoreDifferences:
+  - group: rds.services.k8s.aws
+    kind: DBCluster
+    name: kitchen-teste-sre
+    namespace: teste-sre-dois
+    jsonPointers:
+    - /spec/kmsKeyID
+  sources:
+    - repoURL: "http://chartmuseum.chartmuseum.svc.cluster.local"
+      targetRevision: "v0.4.2"
+      chart: postgres
+      helm:
+        valueFiles:
+        - $values/stg-data-02/teste-sre-dois/postgres/kitchen-teste-sre.yaml
+        fileParameters:
+        - name: variables.cluster
+          path: kubectl://ack-system/configmap/cluster-variables/jsonpath={.data.variables}
+        - name: variables.namespace
+          path: kubectl://teste-sre-dois/configmap/namespace-variables/jsonpath={.data.variables}
+        - name: users.root.data
+          path: kubectl://?teste-sre-dois/secret/kitchen-teste-sre-root-password/jsonpath={.data}
+    - repoURL: "git@github.com:loggi/infrastructure-live.git"
+      targetRevision: HEAD
+      ref: values
+  destination:
+    name: stg-data-02
+    namespace: teste-sre-dois
+  syncPolicy:
+    automated: {}

--- a/stg-data-02/teste-sre-dois/postgres/teste-sre-dois.yaml
+++ b/stg-data-02/teste-sre-dois/postgres/teste-sre-dois.yaml
@@ -1,0 +1,3 @@
+name: kitchen-teste-sre
+
+applications:


### PR DESCRIPTION
# New Postgres
This pull request adds to the kubernetes cluster **stg-data-02** a new Postgres Cluster **kitchen-teste-sre** in the namespace **teste-sre-dois**.

Please be informed that the provisioning time for the Postgres cluster may take from a few minutes to about an hour to be completed. 
However, it is important to note that this time may vary depending on the specifications of your cluster. 
We kindly suggest that you monitor the status of your cluster on the AWS interface to obtain up-to-date information on the provisioning process. 
Should you have any inquiries or require further assistance, please do not hesitate to contact our SRE team.

You can set up user credentials in the following paths of Vault:

The environment variables are:
- KITCHEN_TESTE_SRE_DATABASE_NAME
- KITCHEN_TESTE_SRE_PASSWORD
- KITCHEN_TESTE_SRE_READ_ONLY_HOST
- KITCHEN_TESTE_SRE_READ_WRITE_HOST
- KITCHEN_TESTE_SRE_USER

[Postgres Platform How to Use](https://loggidev.atlassian.net/wiki/spaces/DEVOPS/pages/3429269516/Postgres+Platform+How+to+Use).

Thank you for your attention.
